### PR TITLE
Remove the special per-mount config

### DIFF
--- a/pkg/cvmfs/cvmfsconf.go
+++ b/pkg/cvmfs/cvmfsconf.go
@@ -2,8 +2,6 @@ package cvmfs
 
 import (
 	"io/ioutil"
-	"os"
-	"path"
 	"text/template"
 )
 
@@ -47,26 +45,3 @@ func init() {
 	repoConfTempl = template.Must(template.New("repo-conf").Funcs(fs).Parse(repoConf))
 }
 
-type cvmfsConfigData struct {
-	VolumeId  volumeID
-	Tag, Hash string
-	Proxy     string
-}
-
-func (d *cvmfsConfigData) writeToFile() error {
-	f, err := os.OpenFile(getConfigFilePath(d.VolumeId), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0755)
-	if err != nil {
-		if os.IsExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	defer f.Close()
-
-	return repoConfTempl.Execute(f, d)
-}
-
-func getConfigFilePath(volId volumeID) string {
-	return path.Join(cvmfsConfigRoot, "config-csi-"+string(volId))
-}

--- a/pkg/cvmfs/nodeserver.go
+++ b/pkg/cvmfs/nodeserver.go
@@ -38,18 +38,6 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	confData := cvmfsConfigData{
-		VolumeId: volId,
-		Tag:      volOptions.Tag,
-		Hash:     volOptions.Hash,
-		Proxy:    volOptions.Proxy,
-	}
-
-	if err := confData.writeToFile(); err != nil {
-		glog.Errorf("failed to write cvmfs config for volume %s: %v", volId, err)
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
 	if err := createVolumeCache(volId); err != nil {
 		glog.Errorf("failed to create cache for volume %s: %v", volId, err)
 	}
@@ -166,10 +154,6 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	}
 
 	// Clean up
-
-	if err := os.Remove(getConfigFilePath(volId)); err != nil {
-		glog.Errorf("cvmfs: cannot remove config for volume %s: %v", volId, err)
-	}
 
 	if err := purgeVolumeCache(volId); err != nil {
 		glog.Errorf("cvmfs: cannot delete cache for volume %s: %v", volId, err)

--- a/pkg/cvmfs/volume.go
+++ b/pkg/cvmfs/volume.go
@@ -58,7 +58,6 @@ func mountCvmfs(volOptions *volumeOptions, volId volumeID, mountPoint string) er
 	return execCommandAndValidate("mount",
 		"-t", "cvmfs",
 		volOptions.Repository, mountPoint,
-		"-o", "config="+getConfigFilePath(volId),
 	)
 }
 


### PR DESCRIPTION
As discussed over email, there does not seem to be any reason to create a cpecial, per-mount config in the CSI driver.

This patch removes the creation of such a config, and the default system config is used instead.