### PR TITLE
deployment: temporary set rlimit_nofile

### DIFF
--- a/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
@@ -42,18 +42,21 @@ spec:
           {{- end }}
         - name: nodeplugin
           image: {{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}
-          args:
-            - -v={{ .Values.logVerbosityLevel }}
-            - --nodeid=$(NODE_ID)
-            - --endpoint=$(CSI_ENDPOINT)
-            - --drivername=$(CSI_DRIVERNAME)
-            - --start-automount-daemon={{ .Values.startAutomountDaemon }}
-            - --automount-startup-timeout={{ .Values.automountDaemonStartupTimeout }}
-            - --automount-unmount-timeout={{ .Values.automountDaemonUnmountTimeout }}
-            - --role=identity,node
-            {{- if .Values.cache.alien.enabled }}
-            - --has-alien-cache
-            {{- end }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              ulimit -n {{ .Values._rlimit_nofile }}
+              /csi-cvmfsplugin                                                          \
+                -v={{ .Values.logVerbosityLevel }}                                      \
+                --nodeid=$(NODE_ID)                                                     \
+                --endpoint=$(CSI_ENDPOINT)                                              \
+                --drivername=$(CSI_DRIVERNAME)                                          \
+                --start-automount-daemon={{ .Values.startAutomountDaemon }}             \
+                --automount-startup-timeout={{ .Values.automountDaemonStartupTimeout }} \
+                --automount-unmount-timeout={{ .Values.automountDaemonUnmountTimeout }} \
+                --role=identity,node                                                    \
+                --has-alien-cache={{ .Values.cache.alien.enabled }}
           imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
           securityContext:
             privileged: true

--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -228,3 +228,9 @@ fullNameOverride: ""
 # Extra Kubernetes object metadata labels to be added the ones generated
 # with cvmfs-csi.common.metaLabels template.
 extraMetaLabels: {}
+
+# Temporary workaround for CVMFS client hangs when rlimit_nofile is too high.
+# See https://github.com/cvmfs-contrib/cvmfs-csi/issues/57 for details.
+# NOTE: this value will be deprecated once the issue is fixed.
+# Empty value "" disables the workaround.
+_rlimit_nofile: ""

--- a/deployments/kubernetes/nodeplugin-daemonset.yaml
+++ b/deployments/kubernetes/nodeplugin-daemonset.yaml
@@ -40,12 +40,22 @@ spec:
               mountPath: /registration
         - name: nodeplugin
           image: registry.cern.ch/magnum/cvmfs-csi:v2.0.0
-          args:
-            - -v=5
-            - --nodeid=$(NODE_ID)
-            - --endpoint=$(CSI_ENDPOINT)
-            - --drivername=$(CSI_DRIVERNAME)
-            - --role=identity,node
+          command:
+            - /bin/bash
+            - -c
+            - |
+              # Temporary workaround for CVMFS client hangs when rlimit_nofile is too high.
+              # See https://github.com/cvmfs-contrib/cvmfs-csi/issues/57 for details.
+              ulimit -n 1048576
+
+              /csi-cvmfsplugin                 \
+                -v=5                           \
+                --nodeid=$(NODE_ID)            \
+                --endpoint=$(CSI_ENDPOINT)     \
+                --drivername=$(CSI_DRIVERNAME) \
+                --start-automount-daemon=true  \
+                --role=identity,node           \
+                --has-alien-cache=false
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true


### PR DESCRIPTION
This PR calls `ulimit -n <value>` before launching the CSI driver. See https://github.com/cvmfs-contrib/cvmfs-csi/issues/57 for details. There is no support to set this in Pod spec unfortunately (https://github.com/kubernetes/kubernetes/issues/3595), so the charts & manifests had to be modified.