### PR TITLE
automount config fixes

### DIFF
--- a/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
@@ -49,7 +49,7 @@ spec:
             - --drivername=$(CSI_DRIVERNAME)
             - --start-automount-daemon={{ .Values.startAutomountDaemon }}
             - --automount-startup-timeout={{ .Values.automountDaemonStartupTimeout }}
-            - --automount-unmount-timeout={{ .Values.automountDaemonStartupTimeout }}
+            - --automount-unmount-timeout={{ .Values.automountDaemonUnmountTimeout }}
             - --role=identity,node
             {{- if .Values.cache.alien.enabled }}
             - --has-alien-cache


### PR DESCRIPTION
This PR fixes config issues for automount:
* automount in the image ignores --timeout flag. Write config into /etc/sysconfig/autofs instead.
* helm: used wrong variable for unmount timeout.