### PR TITLE
deployments: bump cvmfs-csi image tags to 2.1.1

### DIFF
--- a/deployments/helm/cvmfs-csi/Chart.yaml
+++ b/deployments/helm/cvmfs-csi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "2.1.0"
+appVersion: "2.1.1"
 description: A Helm chart to deploy the CVMFS-CSI Plugin
 name: cvmfs-csi
-version: 2.1.0
+version: 2.1.1

--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -64,7 +64,7 @@ nodeplugin:
   plugin:
     image:
       repository: registry.cern.ch/magnum/cvmfs-csi
-      tag: v2.1.0
+      tag: v2.1.1
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -143,7 +143,7 @@ controllerplugin:
   plugin:
     image:
       repository: registry.cern.ch/magnum/cvmfs-csi
-      tag: v2.1.0
+      tag: v2.1.1
       pullPolicy: IfNotPresent
     resources: {}
     extraVolumeMounts: []

--- a/deployments/kubernetes/controllerplugin-deployment.yaml
+++ b/deployments/kubernetes/controllerplugin-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: controllerplugin
-          image: registry.cern.ch/magnum/cvmfs-csi:v2.1.0
+          image: registry.cern.ch/magnum/cvmfs-csi:v2.1.1
           imagePullPolicy: IfNotPresent
           args:
             - -v=5

--- a/deployments/kubernetes/nodeplugin-daemonset.yaml
+++ b/deployments/kubernetes/nodeplugin-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: nodeplugin
-          image: registry.cern.ch/magnum/cvmfs-csi:v2.1.0
+          image: registry.cern.ch/magnum/cvmfs-csi:v2.1.1
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
This PR bumps cvmfs-csi image tags to 2.1.1.