### PR TITLE
helm, manifests: add a ConfigMap for /etc/cvmfs/config.d directory

### DIFF
--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -5,6 +5,8 @@
 # These can be used e.g. when defining CVMFS client configuration.
 # ConfigMap data supports go-template expressions.
 extraConfigMaps:
+  # /etc/cvmfs/config.d/
+  cvmfs-csi-config-d: {}
   # /etc/cvmfs/default.local
   cvmfs-csi-default-local:
     default.local: |
@@ -58,6 +60,9 @@ nodeplugin:
   - name: etc-cvmfs-default-conf
     configMap:
       name: cvmfs-csi-default-local
+  - name: etc-cvmfs-config-d
+    configMap:
+      name: cvmfs-csi-config-d
 
   # CVMFS CSI image and container resources specs.
   plugin:
@@ -80,6 +85,8 @@ nodeplugin:
     - name: etc-cvmfs-default-conf
       mountPath: /etc/cvmfs/default.local
       subPath: default.local
+    - name: etc-cvmfs-config-d
+      mountPath: /etc/cvmfs/config.d
 
   # csi-node-driver-registrar image and container resources specs.
   registrar:

--- a/deployments/kubernetes/cvmfs-client-configmap.yaml
+++ b/deployments/kubernetes/cvmfs-client-configmap.yaml
@@ -11,3 +11,11 @@ data:
 
     CVMFS_QUOTA_LIMIT=1000
     CVMFS_CACHE_BASE=/cvmfs-localcache
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cvmfs-csi-config-d
+  labels:
+    app: cvmfs-csi
+data:

--- a/deployments/kubernetes/nodeplugin-daemonset.yaml
+++ b/deployments/kubernetes/nodeplugin-daemonset.yaml
@@ -109,9 +109,11 @@ spec:
               mountPropagation: Bidirectional
             - name: cvmfs-localcache
               mountPath: /cvmfs-localcache
-            - mountPath: /etc/cvmfs/default.local
-              name: etc-cvmfs-default-conf
+            - name: etc-cvmfs-default-conf
+              mountPath: /etc/cvmfs/default.local
               subPath: default.local
+            - name: etc-cvmfs-config-d
+              mountPath: /etc/cvmfs/config.d
       volumes:
         - name: plugin-dir
           hostPath:
@@ -138,7 +140,10 @@ spec:
           emptyDir: {}
         - name: cvmfs-localcache
           emptyDir: {}
-        - configMap:
+        - name: etc-cvmfs-default-conf
+          configMap:
             name: cvmfs-csi-default-local
-          name: etc-cvmfs-default-conf
+        - name: etc-cvmfs-config-d
+          configMap:
+            name: cvmfs-csi-config-d
       priorityClassName: system-node-critical


### PR DESCRIPTION
This PR adds a ConfigMap for `/etc/cvmfs/config.d` directory.

Fixes https://github.com/cvmfs-contrib/cvmfs-csi/issues/72