### PR TITLE
(backport) helm, manifests: add a ConfigMap for config.d dir

### DIFF
--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -5,6 +5,9 @@
 # These can be used e.g. when defining CVMFS client configuration.
 # ConfigMap data supports go-template expressions.
 extraConfigMaps:
+# /etc/cvmfs/config.d/
+- name: cvmfs-csi-config-d
+  data: {}
 # /etc/cvmfs/default.local
 - name: cvmfs-csi-default-local
   data:
@@ -59,6 +62,9 @@ nodeplugin:
   - name: etc-cvmfs-default-conf
     configMap:
       name: cvmfs-csi-default-local
+  - name: etc-cvmfs-config-d
+    configMap:
+      name: cvmfs-csi-config-d
 
   # CVMFS CSI image and container resources specs.
   plugin:
@@ -73,6 +79,8 @@ nodeplugin:
     - name: etc-cvmfs-default-conf
       mountPath: /etc/cvmfs/default.local
       subPath: default.local
+    - name: etc-cvmfs-config-d
+      mountPath: /etc/cvmfs/config.d
 
   # csi-node-driver-registrar image and container resources specs.
   registrar:

--- a/deployments/kubernetes/nodeplugin-daemonset.yaml
+++ b/deployments/kubernetes/nodeplugin-daemonset.yaml
@@ -86,10 +86,10 @@ spec:
               mountPath: /dev
             - name: cvmfs-localcache
               mountPath: /cvmfs-localcache
-            - name: cvmfs-config-default-local
+            - name: etc-cvmfs-default-conf
               mountPath: /etc/cvmfs/default.local
               subPath: default.local
-            - name: cvmfs-config-config-d
+            - name: etc-cvmfs-config-d
               mountPath: /etc/cvmfs/config.d
       volumes:
         - name: plugin-dir
@@ -115,10 +115,10 @@ spec:
             path: /dev
         - name: cvmfs-localcache
           emptyDir: {}
-        - name: cvmfs-config-default-local
+        - name: etc-cvmfs-default-conf
           configMap:
             name: cvmfs-csi-default-local
-        - name: cvmfs-config-config-d
+        - name: etc-cvmfs-config-d
           configMap:
             name: cvmfs-csi-config-d
       priorityClassName: system-node-critical


### PR DESCRIPTION
This is a backport of https://github.com/cvmfs-contrib/cvmfs-csi/pull/73.