### PR TITLE
chart: fix helpers generating duplicit labels

### DIFF
--- a/deployments/helm/cvmfs-csi/templates/_helpers.tpl
+++ b/deployments/helm/cvmfs-csi/templates/_helpers.tpl
@@ -127,7 +127,8 @@ component: controllerplugin
 {{ .Values.nodeplugin.labelsOverride }}
 {{- else -}}
 {{ include "cvmfs-csi.common.metaLabels" . }}
-{{ include "cvmfs-csi.nodeplugin.matchLabels" . }}
+component: nodeplugin
+release: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
@@ -136,6 +137,7 @@ component: controllerplugin
 {{ .Values.controllerplugin.labelsOverride }}
 {{- else -}}
 {{ include "cvmfs-csi.common.metaLabels" . }}
-{{ include "cvmfs-csi.controllerplugin.matchLabels" . }}
+component: controllerplugin
+release: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This PR fixes duplicit labels generated by the chart.

Before:
```yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: release-name-cvmfs-csi-controllerplugin-provisioner
  labels:
    chart: cvmfs-csi-2.1.1
    heritage: Helm
    app: cvmfs-csi
    component: controllerplugin
    app: cvmfs-csi
    release: release-name
```

After:
```yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: release-name-cvmfs-csi-controllerplugin-provisioner
  labels:
    chart: cvmfs-csi-2.1.1
    heritage: Helm
    app: cvmfs-csi
    component: controllerplugin
    release: release-name
```

There are some tools would complain when there were duplicit dict entries.