### PR TITLE
build: added multi-arch support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,40 +1,45 @@
 include:
 - project: 'ci-tools/container-image-ci-templates'
-  file: 'kaniko-image.gitlab-ci.yml'
+  file: 'docker-image.gitlab-ci.yml'
   ref: master
 - project: 'ci-tools/container-image-ci-templates'
   file: 'helm.gitlab-ci.yml'
   ref: master
 
 stages:
-  - build-bin
-  - build-image
-  - build-chart
+- build-bin
+- build-image
+- build-chart
 
 build-bin:
   stage: build-bin
   rules:
-    - if: $CI_COMMIT_BRANCH || $CI_COMMIT_TAG
+  - if: $CI_COMMIT_BRANCH || $CI_COMMIT_TAG
   image: registry.cern.ch/docker.io/library/golang:1.20
   artifacts:
-    expire_in: '10 minutes'
+    expire_in: '10 min'
     paths:
-      - bin/
+    - bin/
   script:
-    - make
+  - make build-cross
 
 build-image:
   rules:
   - if: $CI_COMMIT_TAG
     variables:
       PUSH_IMAGE: "true"
+      IMAGE_TAG: $CI_COMMIT_TAG
   - if: $CI_COMMIT_BRANCH
+    variables:
+      IMAGE_TAG: $CI_COMMIT_BRANCH
   stage: build-image
-  extends: .build_kaniko
+  extends: .build_docker
   variables:
-    REGISTRY_IMAGE_PATH: "registry.cern.ch/magnum/cvmfs-csi:$CI_COMMIT_TAG"
+    REGISTRY_IMAGE_PATH: "registry.cern.ch/kubernetes/cvmfs-csi:$IMAGE_TAG"
     CONTEXT_DIR: "."
     DOCKER_FILE_NAME: "deployments/docker/Dockerfile"
+    PLATFORMS: "linux/amd64,linux/arm64"
+    BUILD_ARGS: "RELEASE=$IMAGE_TAG GITREF=$CI_COMMIT_SHA CREATED=$CI_PIPELINE_CREATED_AT"
 
 build-chart:
   rules:

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -1,12 +1,35 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:9.2-489
 
-LABEL description="CernVM-FS CSI Plugin"
+RUN dnf install -y \
+      # selinux-policy is a dependency of the cvmfs package.
+      # When installing cvmfs on aarch64, an older version of selinux-policy
+      # package is selected for installation which then results in 404.
+      # As a temporary workaround we install it explicitly until this is fixed.
+      selinux-policy \
+      http://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm \
+    && dnf --setopt=install_weak_deps=False install -y cvmfs \
+    && dnf --enablerepo=* clean all && rm -rf /var/cache/yum /var/cache/dnf
 
-RUN dnf install -y http://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && \
-    dnf --setopt=install_weak_deps=False install -y cvmfs && dnf --enablerepo=* clean all && rm -rf /var/cache/yum /var/cache/dnf
+ARG TARGETARCH
+ARG RELEASE
+ARG GITREF
+ARG CREATED
 
-COPY bin/csi-cvmfsplugin /csi-cvmfsplugin
-COPY bin/automount-runner /automount-runner
-COPY bin/singlemount-runner /singlemount-runner
+LABEL org.opencontainers.image.title="cvmfs-csi" \
+      org.opencontainers.image.description="The CernVM-FS CSI image contains tools for exposing CVMFS repositories through Container Storage Interface." \
+      org.opencontainers.image.authors="CernVM-FS CSI authors" \
+      org.opencontainers.image.vendor="CernVM-FS CSI authors" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.documentation="https://github.com/cvmfs-contrib/cvmfs-csi" \
+      org.opencontainers.image.source="https://github.com/cvmfs-contrib/cvmfs-csi" \
+      org.opencontainers.image.url="https://github.com/cvmfs-contrib/cvmfs-csi" \
+      org.opencontainers.image.revision=${GITREF} \
+      org.opencontainers.image.version=${RELEASE} \
+      org.opencontainers.image.created=${CREATED} \
+      org.opencontainers.image.ref.name="" \
+      org.opencontainers.image.base.digest="" \
+      org.opencontainers.image.base.name=""
 
-RUN chmod +x /csi-cvmfsplugin /automount-runner /singlemount-runner
+COPY bin/linux-${TARGETARCH}/csi-cvmfsplugin /csi-cvmfsplugin
+COPY bin/linux-${TARGETARCH}/automount-runner /automount-runner
+COPY bin/linux-${TARGETARCH}/singlemount-runner /singlemount-runner


### PR DESCRIPTION
This PR adds support for multi-arch support into the CI script.

The Makefile has been refactored and the Dockerfile now accepts `TARGETARCH` argument.