### PR TITLE
Pin images and charts to v2.2.1-rc.0

### DIFF
--- a/deployments/helm/cvmfs-csi/Chart.yaml
+++ b/deployments/helm/cvmfs-csi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v2.2.0"
+appVersion: "v2.2.1-rc.0"
 description: A Helm chart to deploy the CVMFS-CSI Plugin
 name: cvmfs-csi
-version: 2.2.0
+version: 2.2.1-rc.0

--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -67,16 +67,16 @@ nodeplugin:
   # CVMFS CSI image and container resources specs.
   plugin:
     image:
-      repository: registry.cern.ch/magnum/cvmfs-csi
-      tag: v2.2.0
+      repository: registry.cern.ch/kubernetes/cvmfs-csi
+      tag: v2.2.1-rc.0
       pullPolicy: IfNotPresent
     resources: {}
 
   # automount-runner image and container resources specs.
   automount:
     image:
-      repository: registry.cern.ch/magnum/cvmfs-csi
-      tag: v2.2.0
+      repository: registry.cern.ch/kubernetes/cvmfs-csi
+      tag: v2.2.1-rc.0
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -91,8 +91,8 @@ nodeplugin:
   # automount-runner image and container resources specs.
   singlemount:
     image:
-      repository: registry.cern.ch/magnum/cvmfs-csi
-      tag: v2.2.0
+      repository: registry.cern.ch/kubernetes/cvmfs-csi
+      tag: v2.2.1-rc.0
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -167,8 +167,8 @@ controllerplugin:
   # CVMFS CSI image and container resources specs.
   plugin:
     image:
-      repository: registry.cern.ch/magnum/cvmfs-csi
-      tag: v2.2.0
+      repository: registry.cern.ch/kubernetes/cvmfs-csi
+      tag: v2.2.1-rc.0
       pullPolicy: IfNotPresent
     resources: {}
     extraVolumeMounts: []

--- a/deployments/kubernetes/controllerplugin-deployment.yaml
+++ b/deployments/kubernetes/controllerplugin-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: controllerplugin
-          image: registry.cern.ch/magnum/cvmfs-csi:v2.2.0
+          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1-rc.0
           imagePullPolicy: IfNotPresent
           command: [/csi-cvmfsplugin]
           args:

--- a/deployments/kubernetes/nodeplugin-daemonset.yaml
+++ b/deployments/kubernetes/nodeplugin-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: nodeplugin
-          image: registry.cern.ch/magnum/cvmfs-csi:v2.2.0
+          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1-rc.0
           command: [/csi-cvmfsplugin]
           args:
             - -v=4
@@ -84,7 +84,7 @@ spec:
               mountPath: /cvmfs
               mountPropagation: Bidirectional
         - name: automount
-          image: registry.cern.ch/magnum/cvmfs-csi:v2.2.0
+          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1-rc.0
           command:
             - /bin/bash
             - -c
@@ -119,7 +119,7 @@ spec:
             - mountPath: /etc/cvmfs/config.d
               name: etc-cvmfs-config-d
         - name: singlemount
-          image: registry.cern.ch/magnum/cvmfs-csi:v2.2.0
+          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1-rc.0
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
This PR pins images and charts to tag v2.2.1-rc.0.

Please note the change in image location: we are moving to `registry.cern.ch/kubernetes`.