### PR TITLE
Pin cvmfs-csi tags to v2.2.1

### DIFF
--- a/deployments/helm/cvmfs-csi/Chart.yaml
+++ b/deployments/helm/cvmfs-csi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v2.2.1-rc.0"
+appVersion: "v2.2.1"
 description: A Helm chart to deploy the CVMFS-CSI Plugin
 name: cvmfs-csi
-version: 2.2.1-rc.0
+version: 2.2.1

--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -68,7 +68,7 @@ nodeplugin:
   plugin:
     image:
       repository: registry.cern.ch/kubernetes/cvmfs-csi
-      tag: v2.2.1-rc.0
+      tag: v2.2.1
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -76,7 +76,7 @@ nodeplugin:
   automount:
     image:
       repository: registry.cern.ch/kubernetes/cvmfs-csi
-      tag: v2.2.1-rc.0
+      tag: v2.2.1
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -92,7 +92,7 @@ nodeplugin:
   singlemount:
     image:
       repository: registry.cern.ch/kubernetes/cvmfs-csi
-      tag: v2.2.1-rc.0
+      tag: v2.2.1
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -168,7 +168,7 @@ controllerplugin:
   plugin:
     image:
       repository: registry.cern.ch/kubernetes/cvmfs-csi
-      tag: v2.2.1-rc.0
+      tag: v2.2.1
       pullPolicy: IfNotPresent
     resources: {}
     extraVolumeMounts: []

--- a/deployments/kubernetes/controllerplugin-deployment.yaml
+++ b/deployments/kubernetes/controllerplugin-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: controllerplugin
-          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1-rc.0
+          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1
           imagePullPolicy: IfNotPresent
           command: [/csi-cvmfsplugin]
           args:

--- a/deployments/kubernetes/nodeplugin-daemonset.yaml
+++ b/deployments/kubernetes/nodeplugin-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: nodeplugin
-          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1-rc.0
+          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1
           command: [/csi-cvmfsplugin]
           args:
             - -v=4
@@ -84,7 +84,7 @@ spec:
               mountPath: /cvmfs
               mountPropagation: Bidirectional
         - name: automount
-          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1-rc.0
+          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1
           command:
             - /bin/bash
             - -c
@@ -119,7 +119,7 @@ spec:
             - mountPath: /etc/cvmfs/config.d
               name: etc-cvmfs-config-d
         - name: singlemount
-          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1-rc.0
+          image: registry.cern.ch/kubernetes/cvmfs-csi:v2.2.1
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
This PR pins cvmfs-csi image and chart to tag v2.2.1.

Please note the change in image location: we are moving to `registry.cern.ch/kubernetes`.