### PR TITLE
Break out HTTP proxy so it is easy to override

### DIFF
--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -1,6 +1,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+cvmfsHttpProxy: "http://ca-proxy.cern.ch:3128"
+
 # Extra ConfigMaps to create and manage by the chart release.
 # These can be used e.g. when defining CVMFS client configuration.
 # ConfigMap data supports go-template expressions.
@@ -11,7 +13,7 @@ extraConfigMaps:
   cvmfs-csi-default-local:
     default.local: |
       CVMFS_USE_GEOAPI=yes
-      CVMFS_HTTP_PROXY="http://ca-proxy.cern.ch:3128"
+      CVMFS_HTTP_PROXY="{{ .Values.cvmfsHttpProxy }}"
 
       # It is advised to change these configs in the cache section of the helm values
       # and leave them unchanged here, so they auto-generate.


### PR DESCRIPTION
This adds a simple place to swap in/out the HTTP proxy without needing to rebuild the entire `default.local` map.