### PR TITLE
Fixed autofs mount expiry

### DIFF
--- a/deployments/helm/README.md
+++ b/deployments/helm/README.md
@@ -102,6 +102,7 @@ Alternatively, a YAML file that specifies the values of the parameters can be pr
 | `kubeletDirectory` | Kubelet's plugin directory path.                                                                                                                 |
 | `cvmfsCSIPluginSocketFile` | Name of the CVMFS CSI socket file.                                                                                                       |
 | `startAutomountDaemon` | Whether CVMFS CSI nodeplugin Pod should run automount daemon.                                                                                |
+| `automountHostPath` | Path on the host where to mount the autofs-managed CVMFS root. The directory will be created if it doesn't exist.                               |
 | `automountStorageClass.create` | Whether a CVMFS CSI storage class using the automounter should be created automatically.                                             |
 | `automountStorageClass.name` | The name for the CVMFS CSI storage class using the automounter if created.                                                             |
 | `specificRepositoryStorageClasses` | A list of specific CVMFS repos you wish to generate a `storageClass` for.                                                        |

--- a/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
@@ -82,9 +82,12 @@ spec:
               readOnly: true
             - name: host-dev
               mountPath: /dev
-            - name: autofs-cvmfs
+            - name: autofs-root
               mountPath: /cvmfs
               mountPropagation: Bidirectional
+            {{- with .Values.nodeplugin.plugin.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.nodeplugin.plugin.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
@@ -113,7 +116,7 @@ spec:
               readOnly: true
             - name: host-dev
               mountPath: /dev
-            - name: autofs-cvmfs
+            - name: autofs-root
               mountPath: /cvmfs
               mountPropagation: Bidirectional
             - name: cvmfs-localcache
@@ -191,10 +194,12 @@ spec:
         - name: host-dev
           hostPath:
             path: /dev
-        - name: autofs-cvmfs
-          emptyDir: {}
         - name: runtime-metadata
           emptyDir: {}
+        - name: autofs-root
+          hostPath:
+            path: {{ .Values.automountHostPath }}
+            type: DirectoryOrCreate
         - name: cvmfs-localcache
           {{- toYaml .Values.cache.local.volumeSpec | nindent 10 }}
         {{- if .Values.cache.alien.enabled }}

--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -234,6 +234,10 @@ kubeletDirectory: /var/lib/kubelet
 # <kubeletPluginDirectory>/plugins/<csiDriverName>/<cvmfsCSIPluginSocketFile>.
 cvmfsCSIPluginSocketFile: csi.sock
 
+# Path on the host where to mount the autofs-managed CVMFS root.
+# The directory will be created if it doesn't exist.
+automountHostPath: /var/cvmfs
+
 # Number of seconds to wait for automount daemon to start up before exiting.
 automountDaemonStartupTimeout: 10
 # Number of seconds of idle time after which an autofs-managed CVMFS mount will


### PR DESCRIPTION
This PR makes it so that the nodeplugin shares its internal /cvmfs autofs root via a hostPath instead of an emptyDir.

kubelet periodically scrapes metrics from all emptyDir volumes by walking trough them recursively, stat()-ing each item. This however resets the autofs mount expiry timeout, making it impossible to automatically unmount unused CVMFS repos. This escaped testing because the mount expiration timeout was shorter than the metrics scraping period.

The workaround for this is to share /cvmfs via a hostPath which is not included by the metrics, avoiding the issue.