### PR TITLE
(Backport #105) chart: fix generating extra ConfigMaps

### DIFF
--- a/deployments/helm/cvmfs-csi/templates/extra-configmaps.yaml
+++ b/deployments/helm/cvmfs-csi/templates/extra-configmaps.yaml
@@ -10,5 +10,7 @@ metadata:
   labels:
     {{- include "cvmfs-csi.common.metaLabels" $ | nindent 4 }}
 data:
-  {{- tpl (toYaml $value) $ | nindent 2 }}
+  {{- range $dataKey, $dataValue := $value }}
+  {{ $dataKey }}: {{ tpl (toYaml $dataValue) $ | indent 2 }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
The tpl invocation on (toYaml $value) breaks the rendered output by removing the newline character at the beginning the $value element.

This commit factors out the tpl invocation to be called only on the actual data value, properly separating the ConfigMap's data entries.

Cherry-pick 6c6a453f8fd26fe13c8ac8b6af26f0adebbb983f (#105).