### PR TITLE
Change chart repo to oci://registry.cern.ch/kubernetes/charts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,4 +50,4 @@ build-chart:
   stage: build-chart
   extends: .deploy_helm
   variables:
-    REGISTRY_PATH: registry.cern.ch/chartrepo/cern
+    REGISTRY_CHART_PATH: registry.cern.ch/kubernetes/charts

--- a/deployments/helm/README.md
+++ b/deployments/helm/README.md
@@ -6,15 +6,9 @@ A Helm chart for the CVMFS-CSI driver, allowing the mounting of CVMFS repositori
 
 You can install the Helm chart from CERN repositories:
 
-Add the repository:
+Helm installation:
 ```
-helm repo add cern https://registry.cern.ch/chartrepo/cern
-helm repo update
-```
-
-Helm v3 installation:
-```
-helm install cvmfs cern/cvmfs-csi
+helm install cvmfs-csi oci://registry.cern.ch/kubernetes/charts/cvmfs-csi --version <Chart tag>
 ```
 
 ### Install from source

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -21,9 +21,7 @@ You may need to customize `cvmfs-csi-default-local` and `cvmfs-csi-config-d` Con
 Helm chart can be installed from CERN registry:
 
 ```bash
-helm repo add cern https://registry.cern.ch/chartrepo/cern
-helm repo update
-helm install cvmfs cern/cvmfs-csi
+helm install cvmfs-csi oci://registry.cern.ch/kubernetes/charts/cvmfs-csi --version <Chart tag>
 ```
 
 Some chart values may need to be customized to suite your CVMFS environment. Please consult the documentation in [../deployments/helm/README.md](../deployments/helm/README.md) to see available values.


### PR DESCRIPTION
This MR the chart push location to `oci://registry.cern.ch/kubernetes/charts` and updates the installation instructions.

Closes: https://github.com/cvmfs-contrib/cvmfs-csi/issues/114