### PR TITLE
deployment: remove the rlimit_nofile workaround

### DIFF
--- a/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
@@ -93,15 +93,11 @@ spec:
           {{- end }}
         - name: automount
           image: {{ .Values.nodeplugin.automount.image.repository }}:{{ .Values.nodeplugin.automount.image.tag }}
-          command:
-            - /bin/bash
-            - -c
-            - |
-              ulimit -n {{ .Values._rlimit_nofile }}
-              /automount-runner                                               \
-                -v={{ .Values.logVerbosityLevel }}                            \
-                --unmount-timeout={{ .Values.automountDaemonUnmountTimeout }} \
-                --has-alien-cache={{ .Values.cache.alien.enabled }}
+          command: [/automount-runner]
+          args:
+            - -v={{ .Values.logVerbosityLevel }}
+            - --unmount-timeout={{ .Values.automountDaemonUnmountTimeout }}
+            - --has-alien-cache={{ .Values.cache.alien.enabled }}
           imagePullPolicy: {{ .Values.nodeplugin.plugin.image.pullPolicy }}
           securityContext:
             privileged: true
@@ -157,14 +153,10 @@ spec:
           {{- end }}
         - name: singlemount
           image: {{ .Values.nodeplugin.singlemount.image.repository }}:{{ .Values.nodeplugin.singlemount.image.tag }}
-          command:
-            - /bin/bash
-            - -c
-            - |
-              ulimit -n {{ .Values._rlimit_nofile }}
-              /singlemount-runner                                             \
-                -v={{ .Values.logVerbosityLevel }}                            \
-                --endpoint=unix:///var/lib/cvmfs.csi.cern.ch/singlemount-runner.sock
+          command: [/singlemount-runner]
+          args:
+            - -v={{ .Values.logVerbosityLevel }}
+            - --endpoint=unix:///var/lib/cvmfs.csi.cern.ch/singlemount-runner.sock
           imagePullPolicy: {{ .Values.nodeplugin.singlemount.image.pullPolicy }}
           securityContext:
             privileged: true

--- a/deployments/kubernetes/nodeplugin-daemonset.yaml
+++ b/deployments/kubernetes/nodeplugin-daemonset.yaml
@@ -85,15 +85,11 @@ spec:
               mountPropagation: Bidirectional
         - name: automount
           image: registry.cern.ch/magnum/cvmfs-csi:latest
-          command:
-            - /bin/bash
-            - -c
-            - |
-              ulimit -n 1000000
-              /automount-runner       \
-                -v=4                  \
-                --unmount-timeout=300 \
-                --has-alien-cache=false
+          command: [/automount-runner]
+          args:
+            - -v=4
+            - --unmount-timeout=300
+            - --has-alien-cache=false
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -120,14 +116,9 @@ spec:
               name: etc-cvmfs-config-d
         - name: singlemount
           image: registry.cern.ch/magnum/cvmfs-csi:latest
-          command:
-            - /bin/bash
-            - -c
-            - |
-              ulimit -n 1000000
-              /singlemount-runner \
-                -v=4              \
-                --endpoint=unix:///var/lib/cvmfs.csi.cern.ch/singlemount-runner.sock
+          command: [/singlemount-runner]
+            - -v=4
+            - --endpoint=unix:///var/lib/cvmfs.csi.cern.ch/singlemount-runner.sock
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true


### PR DESCRIPTION
As of cvmfs v2.11.0 [1] the rlimit_nofile workaround [2] is no longer needed -- this is fixed in the CVMFS client.

[1] https://github.com/cvmfs-contrib/cvmfs-csi/pull/112
[2] https://github.com/cvmfs-contrib/cvmfs-csi/pull/58