### PR TITLE
mount local cache as hostPath; clean it on startup

### DIFF
--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -36,7 +36,9 @@ extraConfigMaps:
 cache:
   local:
     volumeSpec:
-      emptyDir: {}
+      hostPath:
+        path: /var/lib/cvmfs.csi.cern.ch/cache
+        type: DirectoryOrCreate
     # Maximum size of local cache in MiB.
     # CVMFS client will garbage collect the exceeding amount.
     cvmfsQuotaLimit: 1000

--- a/deployments/kubernetes/nodeplugin-daemonset.yaml
+++ b/deployments/kubernetes/nodeplugin-daemonset.yaml
@@ -171,7 +171,9 @@ spec:
         - name: runtime-metadata
           emptyDir: {}
         - name: cvmfs-localcache
-          emptyDir: {}
+          hostPath:
+            path: /var/lib/cvmfs.csi.cern.ch/cache
+            type: DirectoryOrCreate
         - configMap:
             name: cvmfs-csi-default-local
           name: etc-cvmfs-default-conf


### PR DESCRIPTION
This PR sets the local cache directory to be a hostPath instead of an emptyDir. The cache may contain a substantial amount of data, and emptyDir usually won't suffice. Using a hostPath seems like a saner default.

Since the data is now persisted across nodeplugin Pod restarts, we need to clean the directory on startup, otherwise the CVMFS client crashes.