### PR TITLE
(Backport #127) sharedmount: create metadata dir only when running sharedmount-runner

### DIFF
--- a/cmd/singlemount-runner/main.go
+++ b/cmd/singlemount-runner/main.go
@@ -47,17 +47,21 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Initialize and run automount-runner.
+	// Initialize and run singlemount-runner.
 
 	log.Infof("singlemount-runner for CVMFS CSI plugin version %s", cvmfsversion.FullVersion())
 	log.Infof("Command line arguments %v", os.Args)
+
+	if err := singlemount.CreateSingleMountsDir(); err != nil {
+		log.Fatalf("Failed to create metadata directory in %s: %v", singlemount.SinglemountsDir, err)
+	}
 
 	opts := singlemount.Opts{
 		Endpoint: *endpoint,
 	}
 
 	if err := singlemount.RunBlocking(opts); err != nil {
-		log.Fatalf("Failed to run automount-runner: %v", err)
+		log.Fatalf("Failed to run singlemount-runner: %v", err)
 	}
 
 	os.Exit(0)

--- a/internal/cvmfs/singlemount/sharedmount.go
+++ b/internal/cvmfs/singlemount/sharedmount.go
@@ -41,7 +41,7 @@ const (
 	//       bind.json
 	//       config
 	//       mount.json
-	singlemountsDir = "/var/lib/cvmfs.csi.cern.ch/single"
+	SinglemountsDir = "/var/lib/cvmfs.csi.cern.ch/single"
 
 	// Contains mapping between all mountpoint -> mount ID that are currently
 	// in use. We need to keep track of these, because CSI's NodeUnstageVolume
@@ -80,7 +80,7 @@ type (
 )
 
 func fmtMountSingleBasePath(mountID string) string {
-	return path.Join(singlemountsDir, mountID)
+	return path.Join(SinglemountsDir, mountID)
 }
 
 func fmtMountpointPath(mountID string) string {
@@ -100,13 +100,14 @@ func fmtConfigPath(mountID string) string {
 }
 
 func fmtMountpointsMetadataPath() string {
-	return path.Join(singlemountsDir, mountpointsFilename)
+	return path.Join(SinglemountsDir, mountpointsFilename)
 }
 
-func init() {
-	if err := os.MkdirAll(singlemountsDir, 0775); err != nil {
-		panic(err)
-	}
+// Creates the metadata directory for singlemount-runner.
+// Must be called before RunBlocking().
+// TOOD: make the path configurable and expose via the chart.
+func CreateSingleMountsDir() error {
+	return os.MkdirAll(SinglemountsDir, 0775)
 }
 
 // Makes sure that directory <mountsDir>/<MountSingleRequest.MountId> exists.


### PR DESCRIPTION
The directory was created in all cvmfs-csi components (including controllerplugin), because the MkdirAll was called in init() function. This breaks deployments that don't run controllerplugin as root. It doesn't have perms to create the directory, and init() exits with panic().

This commit fixes that by separating the directory creation into another function.

Cherry-pick cabfc114dc4dcdf317f4ab6a85faef8fb3dfa981 (#127)