### PR TITLE
deploy(helm): configure seccomp profile for node & controller plugin

### DIFF
--- a/deployments/helm/README.md
+++ b/deployments/helm/README.md
@@ -73,11 +73,13 @@ Alternatively, a YAML file that specifies the values of the parameters can be pr
 | `nodeplugin.registrar.image.pullPolicy` | Pull policy for csi-node-driver-registrar image.                                                                            |
 | `nodeplugin.registrar.image.resources` | Resource constraints for the `registrar` container.                                                                          |
 | `nodeplugin.updateStrategySpec` | DaemonSet update strategy.                                                                                                          |
+| `nodeplugin.podSecurityContext` | Pod-level security context for nodeplugin DaemonSet.                                                                                |
 | `nodeplugin.priorityClassName` | Pod priority class name of the nodeplugin DaemonSet.                                                                                 |
 | `nodeplugin.nodeSelector` | Pod node selector of the nodeplugin DaemonSet.                                                                                            |
 | `nodeplugin.tolerations` | Pod tolerations of the nodeplugin DaemonSet.                                                                                               |
 | `nodeplugin.affinity` | Pod node affinity of the nodeplugin DaemonSet.                                                                                                |
 | `controllerplugin.name` | Component name for controller plugin component. Used as `component` label value and to generate Deployment name.                            |
+| `controllerplugin.podSecurityContext` | Pod-level security context for controllerplugin deployment.                                                                   |
 | `controllerplugin.plugin.image.repository` | Container image repository for CVMFS CSI controller plugin.                                                              |
 | `controllerplugin.plugin.image.tag` | Container image tag for CVMFS CSI controller plugin.                                                                            |
 | `controllerplugin.plugin.image.pullPolicy` | Pull policy for CVMFS CSI controller plugin image.                                                                       |

--- a/deployments/helm/cvmfs-csi/templates/controllerplugin-deployment.yaml
+++ b/deployments/helm/cvmfs-csi/templates/controllerplugin-deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         {{- include "cvmfs-csi.controllerplugin.labels" .  | nindent 8 }}
     spec:
+      {{- with .Values.controllerplugin.podSecurityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccount: {{ include "cvmfs-csi.serviceAccountName.controllerplugin" . }}
       containers:
         - name: provisioner

--- a/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
@@ -16,6 +16,9 @@ spec:
     spec:
       # hostPID is required for autofs to work.
       hostPID: {{ .Values.nodeplugin.hostPID }}
+      {{- with .Values.nodeplugin.podSecurityContext }}
+      securityContext: {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.nodeplugin.serviceAccount.use }}
       serviceAccount: {{ include "cvmfs-csi.serviceAccountName.nodeplugin" . }}
       {{- end }}

--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -59,12 +59,12 @@ nodeplugin:
 
   # Extra volumes to be appended to nodeplugin's Pod.spec.volumes.
   extraVolumes:
-  - name: etc-cvmfs-default-conf
-    configMap:
-      name: cvmfs-csi-default-local
-  - name: etc-cvmfs-config-d
-    configMap:
-      name: cvmfs-csi-config-d
+    - name: etc-cvmfs-default-conf
+      configMap:
+        name: cvmfs-csi-default-local
+    - name: etc-cvmfs-config-d
+      configMap:
+        name: cvmfs-csi-config-d
 
   # CVMFS CSI image and container resources specs.
   plugin:
@@ -84,11 +84,11 @@ nodeplugin:
     # Extra volume mounts to append to nodeplugin's
     # Pod.spec.containers[name="nodeplugin"].volumeMounts.
     extraVolumeMounts:
-    - name: etc-cvmfs-default-conf
-      mountPath: /etc/cvmfs/default.local
-      subPath: default.local
-    - name: etc-cvmfs-config-d
-      mountPath: /etc/cvmfs/config.d
+      - name: etc-cvmfs-default-conf
+        mountPath: /etc/cvmfs/default.local
+        subPath: default.local
+      - name: etc-cvmfs-config-d
+        mountPath: /etc/cvmfs/config.d
 
   # automount-reconciler image and container resources specs.
   automountReconciler:
@@ -100,11 +100,11 @@ nodeplugin:
     # Extra volume mounts to append to nodeplugin's
     # Pod.spec.containers[name="automountReconciler"].volumeMounts.
     extraVolumeMounts:
-    - name: etc-cvmfs-default-conf
-      mountPath: /etc/cvmfs/default.local
-      subPath: default.local
-    - name: etc-cvmfs-config-d
-      mountPath: /etc/cvmfs/config.d
+      - name: etc-cvmfs-default-conf
+        mountPath: /etc/cvmfs/default.local
+        subPath: default.local
+      - name: etc-cvmfs-config-d
+        mountPath: /etc/cvmfs/config.d
 
   # automount-runner image and container resources specs.
   singlemount:
@@ -166,16 +166,18 @@ nodeplugin:
     serviceAccountName: cvmfs-nodeplugin
 
     # Whether to create ServiceAccount in the CVMFS CSI namespace.
-    # If not, and `use` is set to true, it is expected the ServiceAccount is already present.
+    # If not, and `use` is set to true, it is expected the ServiceAccount is
+    # already present.
     create: false
 
     # Whether to use this ServiceAccount in Node plugin DaemonSet.
     use: false
 
 # CSI Controller plugin Deployment configuration.
-# CVMFS CSI supports volume provisioning, however the provisioned volumes only fulfill the role
-# of a reference to CVMFS repositories used inside the CO (e.g. Kubernetes), and are not modifying
-# the CVMFS store in any way.
+#
+# CVMFS CSI supports volume provisioning, however the provisioned volumes only
+# fulfil the role of a reference to CVMFS repositories used inside the CO
+# (e.g. Kubernetes), and are not modifying the CVMFS store in any way.
 controllerplugin:
 
   # Component name. Used as `component` label value
@@ -208,7 +210,7 @@ controllerplugin:
   deploymentStrategySpec:
     type: RollingUpdate
 
-  # Pod SecurityContext for controllerplugin deployment and daemonset.
+  # Pod-level Security Context for controllerplugin deployment.
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault

--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -133,6 +133,11 @@ nodeplugin:
     # too in order to refresh the mounts.
     type: OnDelete
 
+  # podSecurityContext for nodeplugin daemonset.
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+
   # Pod priority class name.
   priorityClassName: system-node-critical
 
@@ -202,6 +207,11 @@ controllerplugin:
   # Deployment update strategy.
   deploymentStrategySpec:
     type: RollingUpdate
+
+  # Pod SecurityContext for controllerplugin deployment and daemonset.
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
 
   # Pod priority class name.
   priorityClassName: ""

--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -133,7 +133,7 @@ nodeplugin:
     # too in order to refresh the mounts.
     type: OnDelete
 
-  # podSecurityContext for nodeplugin daemonset.
+  # Pod-level security context for nodeplugin daemonset.
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -210,7 +210,7 @@ controllerplugin:
   deploymentStrategySpec:
     type: RollingUpdate
 
-  # Pod-level Security Context for controllerplugin deployment.
+  # Pod-level security context for controllerplugin deployment.
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault


### PR DESCRIPTION
* deploy(helm): configured a seccomp profile of `RuntimeDefault` for `nodeplugin` daemonset and `controllerplugin` deployment.
* chore: formatted helm values file with `yamlfmt` for readability.