### PR TITLE
build(docker): upgrade base ubi image to latest

### DIFF
--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.2-489
+FROM registry.access.redhat.com/ubi9/ubi:9.4-947
 
 ARG TARGETARCH
-ARG REL_VERSION=2.11.0
-ARG PKG_VERSION=2.11.0-1
+ARG REL_VERSION=2.11.3
+ARG PKG_VERSION=2.11.3-1
 
 RUN if [[ "${TARGETARCH}" == "amd64" ]]; then \
     export FRIENDLY_ARCH_NAME="x86_64" ; \


### PR DESCRIPTION
* build(docker): upgrade base ubi image to latest version (`ubi9/ubi:9.4-947`).
* build(cmvfs): upgrade `cvmfs` binaries to latest version (`2.11.3`).

Combined with upgrading to latest version of go + library dependencies this reduces the number of vulnerabilities reported from `trivy` by 95 (195 total remaining). To tackle this further would require likely require running in a distroless image which feels like a large piece of work to plan for. 