### PR TITLE
fix: automount resource reference was referencing wrong object in helm chart

### DIFF
--- a/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
@@ -124,7 +124,7 @@ spec:
             {{- with .Values.nodeplugin.automount.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.nodeplugin.plugin.resources }}
+          {{- with .Values.nodeplugin.automount.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: automount-reconciler


### PR DESCRIPTION
The resource block in the automount container was referencing the plugin values instead of the automount.