### PR TITLE
deploy: plugin image tags default to pull from Chart AppVersion

### DIFF
--- a/deployments/helm/cvmfs-csi/Chart.yaml
+++ b/deployments/helm/cvmfs-csi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "2.1.1"
+appVersion: "v2.4.0"
 description: A Helm chart to deploy the CVMFS-CSI Plugin
 name: cvmfs-csi
-version: 2.1.1
+version: 2.4.0

--- a/deployments/helm/cvmfs-csi/templates/controllerplugin-deployment.yaml
+++ b/deployments/helm/cvmfs-csi/templates/controllerplugin-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: controllerplugin
-          image: {{ .Values.controllerplugin.plugin.image.repository }}:{{ .Values.controllerplugin.plugin.image.tag }}
+          image: {{ .Values.controllerplugin.plugin.image.repository }}:{{ .Values.controllerplugin.plugin.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.controllerplugin.plugin.image.pullPolicy }}
           command: [/csi-cvmfsplugin]
           args:

--- a/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
@@ -44,7 +44,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: nodeplugin
-          image: {{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag }}
+          image: {{ .Values.nodeplugin.plugin.image.repository }}:{{ .Values.nodeplugin.plugin.image.tag | default .Chart.AppVersion }}
           command: [/csi-cvmfsplugin]
           args:
             - -v={{ .Values.logVerbosityLevel }}
@@ -95,7 +95,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: automount
-          image: {{ .Values.nodeplugin.automount.image.repository }}:{{ .Values.nodeplugin.automount.image.tag }}
+          image: {{ .Values.nodeplugin.automount.image.repository }}:{{ .Values.nodeplugin.automount.image.tag | default .Chart.AppVersion }}
           command: [/automount-runner]
           args:
             - -v={{ .Values.logVerbosityLevel }}
@@ -131,7 +131,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: automount-reconciler
-          image: {{ .Values.nodeplugin.automountReconciler.image.repository }}:{{ .Values.nodeplugin.automountReconciler.image.tag }}
+          image: {{ .Values.nodeplugin.automountReconciler.image.repository }}:{{ .Values.nodeplugin.automountReconciler.image.tag | default .Chart.AppVersion }}
           command: [/automount-reconciler]
           args:
             - -v={{ .Values.logVerbosityLevel }}
@@ -155,7 +155,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
         - name: singlemount
-          image: {{ .Values.nodeplugin.singlemount.image.repository }}:{{ .Values.nodeplugin.singlemount.image.tag }}
+          image: {{ .Values.nodeplugin.singlemount.image.repository }}:{{ .Values.nodeplugin.singlemount.image.tag | default .Chart.AppVersion }}
           command: [/singlemount-runner]
           args:
             - -v={{ .Values.logVerbosityLevel }}

--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -52,7 +52,6 @@ cache:
 # Node plugin handles node-local operations, e.g. mounting and unmounting
 # CVMFS repositories.
 nodeplugin:
-
   # Component name. Used as `component` label value
   # and to generate DaemonSet name.
   name: nodeplugin
@@ -70,7 +69,7 @@ nodeplugin:
   plugin:
     image:
       repository: registry.cern.ch/kubernetes/cvmfs-csi
-      tag: v2.3.2
+      tag: "" # If no tag specified default to Chart AppVersion.
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -78,7 +77,7 @@ nodeplugin:
   automount:
     image:
       repository: registry.cern.ch/kubernetes/cvmfs-csi
-      tag: v2.3.2
+      tag: "" # If no tag specified default to Chart AppVersion.
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -94,7 +93,7 @@ nodeplugin:
   automountReconciler:
     image:
       repository: registry.cern.ch/kubernetes/cvmfs-csi
-      tag: v2.3.2
+      tag: "" # If no tag specified default to Chart AppVersion.
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -110,7 +109,7 @@ nodeplugin:
   singlemount:
     image:
       repository: registry.cern.ch/kubernetes/cvmfs-csi
-      tag: v2.3.2
+      tag: "" # If no tag specified default to Chart AppVersion.
       pullPolicy: IfNotPresent
     resources: {}
     # Extra volume mounts to append to nodeplugin's
@@ -121,7 +120,7 @@ nodeplugin:
   registrar:
     image:
       repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-      tag: v2.8.0
+      tag: v2.10.1
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -160,7 +159,6 @@ nodeplugin:
   # New CVMFS CSI deployments do not need this. It is only necessary
   # when upgrading from v1 of the driver.
   serviceAccount:
-
     # Name of the ServiceAccount (to use and/or create).
     # If no name is provided, Helm chart will generate one.
     serviceAccountName: cvmfs-nodeplugin
@@ -179,7 +177,6 @@ nodeplugin:
 # fulfil the role of a reference to CVMFS repositories used inside the CO
 # (e.g. Kubernetes), and are not modifying the CVMFS store in any way.
 controllerplugin:
-
   # Component name. Used as `component` label value
   # and to generate DaemonSet name.
   name: controllerplugin
@@ -193,7 +190,7 @@ controllerplugin:
   plugin:
     image:
       repository: registry.cern.ch/kubernetes/cvmfs-csi
-      tag: v2.3.2
+      tag: "" # If no tag specified default to Chart AppVersion.
       pullPolicy: IfNotPresent
     resources: {}
     extraVolumeMounts: []
@@ -202,7 +199,7 @@ controllerplugin:
   provisioner:
     image:
       repository: registry.k8s.io/sig-storage/csi-provisioner
-      tag: v3.5.0
+      tag: v4.0.1
       pullPolicy: IfNotPresent
     resources: {}
 
@@ -229,7 +226,6 @@ controllerplugin:
 
   # ServiceAccount to use with Controller plugin Deployment.
   serviceAccount:
-
     # Name of the ServiceAccount (to use and/or create).
     # If no name is provided, Helm chart will generate one.
     serviceAccountName: ""
@@ -240,7 +236,6 @@ controllerplugin:
 
   # RBAC rules assigned to the ServiceAccount defined above.
   rbac:
-
     # Whether to create RBACs in the CVMFS CSI namespace.
     # If not, it is expected they are already present.
     create: true


### PR DESCRIPTION
Aims to simplify the release process as tags only need to be updated in `Chart.yaml` file, as if no image tag for plugins are specified it will default to Chart AppVersion.

Tags can still be optionally set in the `values.yaml`.