### PR TITLE
feat: Allow helm template parsing from job scripts

### DIFF
--- a/deployments/helm/cvmfs-csi/templates/prefetcher-configmaps.yaml
+++ b/deployments/helm/cvmfs-csi/templates/prefetcher-configmaps.yaml
@@ -11,7 +11,7 @@ metadata:
 data:
   # Entrypoint for cvmfs-csi prefetcher job mounted at 
   # /etc/cvmfs-csi/prefetcher/entrypoint.sh.
-  entrypoint.sh: {{ toYaml .script | nindent 4 }}
+  entrypoint.sh: {{ tpl .script $ | nindent 4 }}
 
   # Crontab configuration for entrypoint.sh.
   cron.d: |

--- a/deployments/helm/cvmfs-csi/templates/prefetcher-configmaps.yaml
+++ b/deployments/helm/cvmfs-csi/templates/prefetcher-configmaps.yaml
@@ -11,7 +11,8 @@ metadata:
 data:
   # Entrypoint for cvmfs-csi prefetcher job mounted at 
   # /etc/cvmfs-csi/prefetcher/entrypoint.sh.
-  entrypoint.sh: {{ tpl .script $ | nindent 4 }}
+  entrypoint.sh: |
+    {{- tpl .script $ | nindent 4 }}
 
   # Crontab configuration for entrypoint.sh.
   cron.d: |


### PR DESCRIPTION
This is useful for helm to replace values in the script, which depend on other values present in the chart.

For instance, the SWAN service uses cronjobs to prefetch and source the most recent LCG releases that users can select in the session setup form. Until this moment, we had to update the latest LCGs in the session setup form and the path to the new LCGs to be sourced in the job.

With this change, we only need to do it in one place and helm will automatically replace the path to the latest LCG releases from CVMFS directly in the script script, instead of having to do that manually.

So now, we would have something like this:

```yaml
nodeplugin:
      prefetcher:
        enabled: true
        # Jobs to warmup the latest LCG, ROOT, NXCALS and CUDA stacks respectively
        jobs:
          - name: cron-warmup-lcg-releases
            schedule: "*/15 * * * *"
            script: |-
              #!/bin/bash

              source /cvmfs/sft.cern.ch/lcg/views/{{ .Values.global.generic.lcg }}/{{ .Values.global.generic.platform }}/setup.sh &&
              (timeout 20s python3 -m ipykernel > /dev/null 2>&1 || true)

              source /cvmfs/sft.cern.ch/lcg/views/{{ .Values.global.generic.lcg }}/{{ .Values.global.generic.platform }}/setup.sh &&
              (timeout 20s python3 -m JupyROOT.kernel.rootkernel > /dev/null 2>&1 || true)

              source /cvmfs/sft.cern.ch/lcg/views/{{ .Values.global.nxcals.lcg }}/{{ .Values.global.nxcals.platform }}/setup.sh &&
              (timeout 20s python3 -m ipykernel > /dev/null 2>&1 || true) &&
              (timeout 20s python3 -c 'import pyspark' || true)

              (lsmod | grep nvidia) &&
              source /cvmfs/sft.cern.ch/lcg/views/{{ .Values.global.cuda.lcg }}/{{ .Values.global.cuda.platform }}/setup.sh &&
              (timeout 20s python3 -c 'import tensorflow' || true) &&
              (timeout 20s python3 -c 'import torch' || true)

```