### PR TITLE
Add mount override for /etc/cvmfs/default.d/90-local.conf 

### DIFF
--- a/deployments/helm/cvmfs-csi/values.yaml
+++ b/deployments/helm/cvmfs-csi/values.yaml
@@ -25,6 +25,17 @@ extraConfigMaps:
       # Whether repositories should share a cache directory or each have their own.
       CVMFS_SHARED_CACHE=no
       {{- end -}}
+  # /etc/cvmfs/default.d/90-local.conf
+  cvmfs-csi-default-d: {}
+  #  90-local.conf: |
+       # This is the OSG configuration file for the CVMFS client.
+       # It will overwride the default configuration file which uses the cern config repo
+  #    CVMFS_SEND_INFO_HEADER=yes
+  #    CVMFS_KEYS_DIR=/etc/cvmfs/keys/opensciencegrid.org
+  #    CVMFS_USE_GEOAPI=yes
+  #    CVMFS_CONFIG_REPOSITORY=config-osg.opensciencegrid.org
+  #    CVMFS_CONFIG_REPO_REQUIRED=yes
+  #    CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.fnal.gov:3126;http://cvmfsbproxy.cern.ch:3126"
 
 # Cache configuration for storing CVMFS client data.
 # CVMFS CSI supports two kinds of caches:
@@ -64,6 +75,9 @@ nodeplugin:
     - name: etc-cvmfs-config-d
       configMap:
         name: cvmfs-csi-config-d
+    - name: etc-cvmfs-default-d
+      configMap:
+        name: cvmfs-csi-default-d
 
   # CVMFS CSI image and container resources specs.
   plugin:
@@ -88,6 +102,9 @@ nodeplugin:
         subPath: default.local
       - name: etc-cvmfs-config-d
         mountPath: /etc/cvmfs/config.d
+      - name: etc-cvmfs-default-d
+        mountPath: /etc/cvmfs/default.d/90-local.conf
+        subPath: 90-local.conf
 
   # automount-reconciler image and container resources specs.
   automountReconciler:
@@ -104,6 +121,9 @@ nodeplugin:
         subPath: default.local
       - name: etc-cvmfs-config-d
         mountPath: /etc/cvmfs/config.d
+      - name: etc-cvmfs-default-d
+        mountPath: /etc/cvmfs/default.d/90-local.conf
+        subPath: 90-local.conf
 
   # Prefetch cvmfs repos on a schedule to keep client cache warm.
   prefetcher:

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -251,11 +251,14 @@ drwxrwxr-x   57 999      997             68 Aug 13 03:43 sw
 
 ## Adding CVMFS repository configuration
 
-All CVMFS client configuration is stored in two ConfigMaps (created in CVMFS CSI's namespace):
+All CVMFS client configuration is stored in three ConfigMaps (created in CVMFS CSI's namespace):
 * ConfigMap `cvmfs-csi-default-local` mounted under `/etc/cvmfs/default.local` file,
 * ConfigMap `cvmfs-csi-config-d` mounted under `/etc/cvmfs/config.d` directory.
+* ConfigMap `cvmfs-csi-default-d` mounted under `/etc/cvmfs/default.d/90-local.conf` directory.
 
 To add or change repository configuration, run `kubectl edit configmap cvmfs-csi-config-d` and edit the ConfigMap items accordingly. Note that it may take some time until the updated ConfigMap contents get propagated to all nodes and CVMFS clients to pick up the new changes.
+
+The `cvmfs-csi-default-d` config map is designed to be used for settings that are only allowed in the default.d/*.conf directory.  For example, the only place that the cern config repo can be overridden is in the default.d directory.
 
 ### Example: adding ilc.desy.de CVMFS repository
 


### PR DESCRIPTION
The default CVMFS package installs /etc/cvmfs/default.d/50-cern.conf which defines the config repo.  The only place that a config repo can defined is default.local or in default.d directory, so to change the config repo (for example, to use the OSG config repo) you must add a new file, to be read after 50-cern.conf to the default.d directory.

An example is shown in the `values.yaml` file, but also here for what would be required to use the OSG config repo.
```yaml
  cvmfs-csi-default-d:
    90-local.conf: |
      CVMFS_SEND_INFO_HEADER=yes
      CVMFS_KEYS_DIR=/etc/cvmfs/keys/opensciencegrid.org
      CVMFS_USE_GEOAPI=yes
      CVMFS_CONFIG_REPOSITORY=config-osg.opensciencegrid.org
      CVMFS_CONFIG_REPO_REQUIRED=yes
      CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.fnal.gov:3126;http://cvmfsbproxy.cern.ch:3126"
```

This is in use on the U.S. [National Research Platform](https://docs.nationalresearchplatform.org/userdocs/storage/cvmfs/).