### PR TITLE
Use modern name for serviceAccount field

### DIFF
--- a/deployments/helm/cvmfs-csi/templates/controllerplugin-deployment.yaml
+++ b/deployments/helm/cvmfs-csi/templates/controllerplugin-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       {{- with .Values.controllerplugin.podSecurityContext }}
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccount: {{ include "cvmfs-csi.serviceAccountName.controllerplugin" . }}
+      serviceAccountName: {{ include "cvmfs-csi.serviceAccountName.controllerplugin" . }}
       containers:
         - name: provisioner
           image: {{ .Values.controllerplugin.provisioner.image.repository }}:{{ .Values.controllerplugin.provisioner.image.tag }}

--- a/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
+++ b/deployments/helm/cvmfs-csi/templates/nodeplugin-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeplugin.serviceAccount.use }}
-      serviceAccount: {{ include "cvmfs-csi.serviceAccountName.nodeplugin" . }}
+      serviceAccountName: {{ include "cvmfs-csi.serviceAccountName.nodeplugin" . }}
       {{- end }}
       containers:
         - name: registrar


### PR DESCRIPTION
Th `serviceAccount` field has been deprecated for a while. The `serviceAccountName` field should be present across any cluster likly to run this daemon set.